### PR TITLE
update account token variable for Enterprise GitHub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ venv/
 *.csv
 *.xlsx
 *.log
+.DS_Store

--- a/gh_search.py
+++ b/gh_search.py
@@ -4,7 +4,7 @@ from github import Github
 import logging
 import time
 
-ACCESS_TOKEN = config.gh_api_key
+ACCESS_TOKEN = config.egh_api_key
 API_ENDPOINT = config.egh_api_endpoint
 
 g = Github(ACCESS_TOKEN)


### PR DESCRIPTION
Since I'm using Enterprise version of GitHub and have set the egh_api_key variable in config.json, then gh_search.py must also use egh_api_key.