### PR TITLE
chore(docs): Markdown linting and a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@ One script, `gh_search.py`, takes an inventory of which files contain keywords t
 
 Another script, `gh_default_branch.py`, looks for repos that still have the default branch set to `master` instead of `main`. You could modify that script to create an Issue automatically in any repo that meets that criteria, or run the script as a report for analysis.
 
-To use these scripts, you must create a `config.py` file that contains a GitHub personal access token. The [GitHub docs describe creating a personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token). You'll notice that the `.gitignore` file in this repo ignores any file named `config.py`. 
+To use these scripts, you must create a `config.py` file that contains a GitHub personal access token. The [GitHub docs describe creating a personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token). You'll notice that the `.gitignore` file in this repo ignores any file named `config.py`.
 
 Note that the script can only look for repos that your GitHub user has access to, so private repos that you don't have access to will not be included in the search query.
 
 Example `config.py`:
-```
+
+```python
 gh_api_key = "ghp_TotallyaFaKeTok3nIprom1seYouS0d0ntTrYit"
 gh_orgname = "cisco-open"
 ```
@@ -22,32 +23,33 @@ The `gh_search.py` file is a Python example using the REST API and the `PyGitHub
 
 If you want to search Enterprise GitHub, you can add the Enterprise GitHub API Endpoint and access token to the `config.py` file. Here's an example:
 
-```
+```python
 egh_orgname = "DevNet-org"
 egh_api_endpoint = "https://internal-github.example.com/api/v3"
 egh_api_key = "ghp_TotallyaFaKeTok3nIprom1seYouS0d0ntTrYit"
 ```
 
 To get a list of repos with a keyword in certain files:
+
 1. Create a `config.py` file in the root of the repository with your [GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) with "repo" scope.
-   ```
+   ```python
    gh_api_key = "ghp_TotallyaFaKeTok3nIprom1seYouS0d0ntTrYit"
    gh_orgname = "cisco-open"
    ```
 2. Create a Python virtual environment:
-   ```
+   ```shell
    python -m venv venv
    ```
 3. Source the virtual environment. 
    On Windows: `venv\Scripts\activate.bat` 
    On Mac or Linux: `source venv/bin/activate`
 4. Install the dependencies, namely the `PyGitHub` library: 
-   ```
+   ```shell
    pip install -r requirements.txt
    ```
 5. Run the script and enter the keyword and file type you want to collect an inventory for. Here's an example:
-   
-   ```
+
+   ```shell
    python gh_search.py
    ```
    ```
@@ -65,6 +67,7 @@ To get a list of repos with a keyword in certain files:
 The `gh_default_branch.py` script uses some filtering to get a subset of repositories in a large GitHub org to see if the default branch is still set to "master" rather than "main." The default setting for the script writes out a report listing the repo names. A commented-out line shows an example of creating an Issue in the repo letting the maintainers know that we want them to change their default branch to one named `main` to meet the organization's standards.
 
 To get a list of repos that have a keyword in the repo name that use `master` as the default branch:
+
 1. Create a `config.py` file in the root of the repository with your [GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) with "repo" scope.
 2. Create a Python virtual environment: `python -m venv venv`.
 3. Source the virtual environment. On Windows: `venv\Scripts\activate.bat` On Mac or Linux: `source venv/bin/activate`.

--- a/bash-script-inventory.md
+++ b/bash-script-inventory.md
@@ -6,7 +6,7 @@ You can `git clone` all the repos you want to analyze, then use Bash scripts to 
 
 First, get a list of all repos names where you want to search in text files for a term. In this case, we are searching for `master` to look for branch names and links containing `master`.
 
-> Note: For DevNet Learning Labs, we use a private Learning Labs API to get a list of all the repos using a `learning_lab_api.py` script from a `docs-helpers` toolset. 
+> Note: For DevNet Learning Labs, we use a private Learning Labs API to get a list of all the repos using a `learning_lab_api.py` script from a `docs-helpers` toolset.
 
 ## Using Bash with grep to look for keywords
 
@@ -14,9 +14,9 @@ Clone all your repos of interest locally so you can search within the text files
 
 Once you have copies of all the repos locally, run this script to search for the string `/master/` (include the backslashes when looking for master in a URL). You would remove the backslashes if you are searching for any use of the word "master".
 
-This script searches for the keyword in a "labs" directory in each repo, then it adds any hits it finds to a text file within the root of the repo folder. 
+This script searches for the keyword in a "labs" directory in each repo, then it adds any hits it finds to a text file within the root of the repo folder.
 
-```
+```bash
 for dir in */; do
     cd $dir
     length=$((${#dir} - 1));
@@ -29,7 +29,7 @@ done
 
 Now, in each folder/repo locally, you have a `.txt` file that indicates any mentions of `/master/` in that repo. You can then run another script that puts all those listed repos and files together into one long inventory list:
 
-```
+```bash
 for dir in */; do
     echo "$dir"
     cd $dir
@@ -42,10 +42,11 @@ done
 ```
 
 Now you can look at the `all-master-links-lists.txt` file to see which repos have a reference to "/master/" in any file in the "labs" directory:
-```
+
+```shell
 cat all-master-links-lists.txt
 ```
 
 One way that you could compare how many references to "master" were in URLs versus how many references to "master" were in code commands or text was by looking at the difference between running these scripts with and without the backslashes surrounding "/master/." It's safe to estimate that any use of master without backslashes was in a command or text rather than in a URL.
 
-In running these on more than 100 repos as a data point for reference, we also found there were no non-GitHub references to "master," which was also a good data point. 
+In running these on more than 100 repos as a data point for reference, we also found there were no non-GitHub references to "master," which was also a good data point.

--- a/bash-script-inventory.md
+++ b/bash-script-inventory.md
@@ -46,6 +46,6 @@ Now you can look at the `all-master-links-lists.txt` file to see which repos hav
 cat all-master-links-lists.txt
 ```
 
-One way that you could compare how many references to "master" were in URLs versus how many references to "master" were in code comands or text was by looking at the difference between running these scripts with and without the backslashes surrounding "/master/." It's safe to estimate that any use of master without backslashes was in a command or text rather than in a URL. 
+One way that you could compare how many references to "master" were in URLs versus how many references to "master" were in code commands or text was by looking at the difference between running these scripts with and without the backslashes surrounding "/master/." It's safe to estimate that any use of master without backslashes was in a command or text rather than in a URL.
 
 In running these on more than 100 repos as a data point for reference, we also found there were no non-GitHub references to "master," which was also a good data point. 


### PR DESCRIPTION
This PR fixes a single trivial typo, as well as adjusts some Markdown linting warnings (such as defining the code in a code fence, trailing whitespace, etc, without changing the visual formatting of the resulting output).

Thanks for putting the repo together!