### PR TITLE
Introducing Dependabot grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,18 +6,27 @@
 ---
 version: 2
 updates:
-- package-ecosystem: "pip"
-  directory: "/"
-  schedule:
-    interval: "weekly"
-  open-pull-requests-limit: 10
-- package-ecosystem: "docker"
-  directory: "/"
-  schedule:
-    interval: "weekly"
-  open-pull-requests-limit: 10
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    interval: "weekly"
-  open-pull-requests-limit: 10
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      python-packages:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github:
+        patterns:
+          - "actions/*"
+          - "github/*"
+    open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,11 +15,6 @@ updates:
         patterns:
           - "*"
     open-pull-requests-limit: 10
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Description

Dependabot has [rolled out a public beta](https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/) for custom grouping rules based on pattern-matching package names. Certain patterns [can also be excluded](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) (although I wasn't sure if any exclusions would apply to this project, so left alone for now).

### Adds

* Grouped updates for `pip` (python) and `github-actions` packages
  * ⚠️ Currently in public beta / subject to change

### Removes

* (_Seemingly_) unused `docker` rules from Dependabot config
  * 🐳 Let me know if this should stay put!

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)
