### PR TITLE
Update Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,76 +1,29 @@
-# This workflow uses actions that are not certified by GitHub. They are provided
-# by a third-party and are governed by separate terms of service, privacy
-# policy, and support documentation.
+name: scorecard
 
-name: Scorecard supply-chain security
 on:
-  # For Branch-Protection check. Only the default branch is supported. See
-  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
-  branch_protection_rule:
-  # To guarantee Maintained check is occasionally updated. See
-  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
-  schedule:
-    - cron: '20 7 * * 2'
   push:
-    branches: ["main"]
+    branches:
+      # Run on pushes to default branch
+      - main
+  schedule:
+    # Run weekly on Saturdays
+    - cron: "30 1 * * 6"
+  # Run when branch protection rules change
+  branch_protection_rule:
+  # Run the workflow manually
+  workflow_dispatch:
 
-# Declare default permissions as read only.
+# Declare default permissions as read-only
 permissions: read-all
 
 jobs:
-  analysis:
-    name: Scorecard analysis
-    runs-on: ubuntu-latest
+  run-scorecard:
+    # Call reusable workflow file
+    uses: cisco-ospo/.github/.github/workflows/_scorecard.yml@main
     permissions:
-      # Needed to upload the results to code-scanning dashboard.
-      security-events: write
-      # Needed to publish results and get a badge (see publish_results below).
       id-token: write
-      contents: read
-      actions: read
-
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
-        with:
-          egress-policy: audit
-
-      - name: "Checkout code"
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          persist-credentials: false
-
-      - name: "Run analysis"
-        uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # v2.3.1
-        with:
-          results_file: results.sarif
-          results_format: sarif
-          # (Optional) "write" PAT token. Uncomment the `repo_token` line below if:
-          # - you want to enable the Branch-Protection check on a *public* repository, or
-          # - you are installing Scorecards on a *private* repository
-          # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action#authentication-with-pat.
-          # repo_token: ${{ secrets.SCORECARD_TOKEN }}
-
-          # Public repositories:
-          #   - Publish results to OpenSSF REST API for easy access by consumers
-          #   - Allows the repository to include the Scorecard badge.
-          #   - See https://github.com/ossf/scorecard-action#publishing-results.
-          # For private repositories:
-          #   - `publish_results` will always be set to `false`, regardless
-          #     of the value entered here.
-          publish_results: true
-
-      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
-      # format to the repository Actions tab.
-      - name: "Upload artifact"
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
-        with:
-          name: SARIF file
-          path: results.sarif
-          retention-days: 5
-
-      # Upload the results to GitHub's code scanning dashboard.
-      - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@407ffafae6a767df3e0230c3df91b6443ae8df75 # v2.22.8
-        with:
-          sarif_file: results.sarif
+      security-events: write
+    secrets: inherit
+    with:
+      # Publish results of Scorecard analysis
+      publish-results: true


### PR DESCRIPTION
## Description

As part of a broader effort to roll out Scorecard across our Cisco Open projects, we're moving towards a [reusable workflow](https://docs.github.com/en/actions/using-workflows/reusing-workflows) model which allows the building blocks of a typical Scorecard workflow to be defined and updated in a [single location](https://github.com/cisco-ospo/.github/blob/main/.github/workflows/_scorecard.yml). This reduces the amount of duplicate configuration and dependency management toil across repositories, while still allowing maintainers to customize workflow triggers such as target branch, schedule cadence, and more.

Note that the one "breaking change" to this workflow involves changing the current cron schedule from `20 7 * * 2` (Tuesdays) to `30 1 * * 6` (Saturdays). If Tuesdays had been previously selected for a specific reason, feel free to suggest a change reverting to the original cadence!

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)
